### PR TITLE
Allow static getResource function generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,10 @@ Release/
 # Editors temporary files
 *~
 *.autosave
+
+
+#############
+## Linux
+#############
+
+vsrd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+script: if [ "$CXX" = "g++" ]; then make -f Makefile-gcc; else if [ "$CXX" = "clang++" ]; then make -f Makefile-clang; fi; fi

--- a/CmdLine.cpp
+++ b/CmdLine.cpp
@@ -8,6 +8,7 @@ CmdLine::CmdLine(int argc, const char **argv)
         std::cout << "\nUsage: " << argv[0] << " [-t] [input_file] [-o output_file]\n" <<
             "\t-o         file to be writen to. WILL BE OVERRIDEN.\n" <<
             "\t--header   create a header file to be used in your project.\n" <<
+            "\t--static   make getResource static.\n" <<
             "\tinput_file resources definition file\n\n";
         exit(0);
     }
@@ -15,6 +16,7 @@ CmdLine::CmdLine(int argc, const char **argv)
     this->m_inputFile  = "";
     this->m_outputFile = "";
     this->m_operation  = DumpResources;
+    this->m_static = false;
 
     const char *c;
     for ( int i = 1; i < argc; ++i ) {
@@ -22,6 +24,11 @@ CmdLine::CmdLine(int argc, const char **argv)
 
         if ( strcmp(c, "--header") == 0 ) {
             this->m_operation = DumpHeader;
+            continue;
+        }
+
+        if ( strcmp(c, "--static") == 0 ) {
+            this->m_static = true;
             continue;
         }
 

--- a/CmdLine.cpp
+++ b/CmdLine.cpp
@@ -1,4 +1,7 @@
-﻿#include "CmdLine.h"
+#include "CmdLine.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 #include <iostream>
 

--- a/CmdLine.h
+++ b/CmdLine.h
@@ -1,4 +1,4 @@
-﻿#ifndef CMDLINE_H
+#ifndef CMDLINE_H
 #define CMDLINE_H
 
 enum Operation {

--- a/CmdLine.h
+++ b/CmdLine.h
@@ -26,9 +26,15 @@ public:
         return m_operation;
     }
 
+    bool is_static() const
+    {
+        return m_static;
+    }
+
 protected:
     const char *m_inputFile;
     const char *m_outputFile;
     Operation  m_operation;
+    bool m_static;
 };
 #endif

--- a/Dumper.cpp
+++ b/Dumper.cpp
@@ -1,4 +1,7 @@
-﻿#include "Dumper.h"
+#include "Dumper.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 #include <fstream>
 #include <iostream>

--- a/Dumper.cpp
+++ b/Dumper.cpp
@@ -67,7 +67,7 @@ void dumpHeader(const char *file)
     out.close();
 }
 
-void dumpC(const char *dst_file, std::map<std::string, std::string> files, std::string relative_path)
+void dumpC(const char *dst_file, std::map<std::string, std::string> files, std::string relative_path, bool is_static)
 {
     std::ofstream dst(dst_file, std::ios::binary | std::ios::out);
 
@@ -110,6 +110,11 @@ void dumpC(const char *dst_file, std::map<std::string, std::string> files, std::
 
         f.close();
         i++;
+    }
+
+    if (is_static)
+    {
+        dst << "static ";
     }
 
     dst << "const char* getResource(const char* resource, unsigned long long *size)\n{\n";

--- a/Dumper.h
+++ b/Dumper.h
@@ -1,4 +1,4 @@
-﻿#ifndef DUMPER_H
+#ifndef DUMPER_H
 #define DUMPER_H
 
 #include <map>

--- a/Dumper.h
+++ b/Dumper.h
@@ -5,5 +5,5 @@
 #include <string>
 
 void dumpHeader(const char *file);
-void dumpC(const char *dst_file, std::map<std::string, std::string> files, std::string relative_path);
+void dumpC(const char *dst_file, std::map<std::string, std::string> files, std::string relative_path, bool is_static);
 #endif

--- a/Main.cpp
+++ b/Main.cpp
@@ -1,4 +1,4 @@
-﻿#include "CmdLine.h"
+#include "CmdLine.h"
 #include "Dumper.h"
 #include "Parser.h"
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char const **argv)
                 rp = ".";
             }
 
-            dumpC(cmdline.output(), files, rp);
+            dumpC(cmdline.output(), files, rp, cmdline.is_static());
             break;
     }
 

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -1,4 +1,7 @@
-﻿#include "Parser.h"
+#include "Parser.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 #include <iostream>
 #include <fstream>

--- a/Parser.h
+++ b/Parser.h
@@ -1,4 +1,4 @@
-﻿#ifndef PARSER_H
+#ifndef PARSER_H
 #define PARSER_H
 
 #include <map>


### PR DESCRIPTION
Static function generation might be useful when you want to use different resources accross different compilation units.

The second commit is mainly fixing some Linux issues.
